### PR TITLE
ci: switch image registry to docker.pdlab.dev

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -14,7 +14,7 @@ permissions:
   pull-requests: write
 
 env:
-  NEXUS_REGISTRY: docker.toastedbytes.com
+  NEXUS_REGISTRY: docker.pdlab.dev
 
 jobs:
   # PR builds: Test and validate only, no deployment


### PR DESCRIPTION
Part of pdlab.dev migration. Sealed secret has dual-auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)